### PR TITLE
Add a few more details to Readme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,15 +6,16 @@
 A Webpack plugin to enable hot reloading while developing Chrome extensions.
 
 ## Solution for ...
-Have your ever being annoyed while developing a Google Chrome extension, and being unable to use 
+Have your ever being annoyed while developing a Google Chrome extension, and being unable to use
 webpack-hot-server because it's not a web app but a browser extension?
 
 Well, now you can do hot reloading!
 
 ## What it does?
 Basically something similar to what the webpack hot reload middleware does. When you change the code and the webpack
-trigger and finish the compilation, your extension is notified and then reloaded using the chrome.runtime API.
- 
+trigger and finish the compilation, your extension is notified and then reloaded using the chrome.runtime API.  Check out
+[Hot reloading Chrome extensions using Webpack](https://medium.com/front-end-hacking/hot-reloading-extensions-using-webpack-cdfa0e4d5a08) for more background.
+
 ## Warning!
 This plugin still under development, so maybe some features are missing. Of course, it's open to any PR's to improve that!
 

--- a/README.MD
+++ b/README.MD
@@ -21,19 +21,16 @@ This plugin still under development, so maybe some features are missing. Of cour
 
 ## How to use
 
-First import the module
+Add `webpack-chrome-extension-reloader` to the plugins section of your webpack configuration file.
 ```js
 const ChromeExtensionReloader  = require('webpack-chrome-extension-reloader');
-```
 
-And then, just add it to the plugins section of the webpack configuration file.
-```js
 plugins: [
     new ChromeExtensionReloader() // ONLY USE IT IN DEVELOPMENT BUILD!
 ]
 ```
 
-You can also inform some options (the following are the default ones):
+You can also set some options (the following are the default ones):
 ```js
 plugins: [
     new ChromeExtensionReloader({
@@ -44,8 +41,18 @@ plugins: [
         background: 'background'
       }
     })
-]
+],
+entry: {
+    'content-script': './my-content-script.js',
+    background: './my-background-script.js'
+}
 ```
+
+**Note:**
+You must have both background and content scripts for this plugin to work, and they must be specified in separate `entry` chunks
+in your webpack config.
+
+You can find an example extension project configuration in the `sample` folder of this repo.
 
 ### License
 This project is under the [MIT LICENSE](http://opensource.org/licenses/MIT)


### PR DESCRIPTION
As a newcomer to both this project and to chrome extension development in general, I struggled a little to understand how to set this up.  I've taken a shot at adding a few more notes to the readme that I think would have helped me.

As another suggestion, it might be nice to throw an error if the plugin can't find both a `contentScript` and a `background` chunk/entry.  It took me a while to figure out why it wasn't working, when I originally didn't have a background script.