### PR TITLE
use cross-env for building/testing in any environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "git://github.com/rubenspgcavalcante/webpack-chrome-extension-reloader.git"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack",
-    "test": "NODE_ENV=test webpack && mocha dist/tests.js",
-    "watch": "NODE_ENV=development webpack --watch",
+    "build": "cross-env NODE_ENV=production webpack",
+    "test": "cross-env NODE_ENV=test webpack && mocha dist/tests.js",
+    "watch": "cross-env NODE_ENV=development webpack --watch",
     "sample": "webpack --config sample/webpack.plugin.js --watch",
     "prepublish": "npm run build"
   },
@@ -59,6 +59,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "chai": "^4.0.2",
     "copy-webpack-plugin": "^4.0.1",
+    "cross-env": "^5.0.5",
     "css-loader": "^0.28.4",
     "extract-text-webpack-plugin": "^2.1.2",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
Trying to run npm run build on Windows is failing to set an environment variable.
Support other environments with this change.