### PR TITLE
allow excluding chunks which don't run in a chrome context

### DIFF
--- a/src/ChromeExtensionReloader.ts
+++ b/src/ChromeExtensionReloader.ts
@@ -12,7 +12,7 @@ export default class ChromeExtensionReloader extends AbstractChromePluginReloade
     constructor(options?: PluginOptions) {
         super();
         this._hash = '';
-        this._opts = {reloadPage: true, port: 9090, ...options};
+        this._opts = {reloadPage: true, port: 9090, excludedChunks: [], ...options};
         this._opts.entries = {contentScript: 'contentScript', background: 'background', ...this._opts.entries};
 
         this._source = middlewareSourceBuilder({
@@ -23,7 +23,7 @@ export default class ChromeExtensionReloader extends AbstractChromePluginReloade
 
     apply(compiler) {
         const {port, reloadPage} = this._opts;
-        compiler.plugin("compilation", compilation => middlewareInjector(compilation, this._source));
+        compiler.plugin("compilation", compilation => middlewareInjector(compilation, this._source, this._opts.excludedChunks));
 
         console.info(green("[ Starting the Chrome Hot Plugin Reload Server... ]"));
         const server = new HotReloaderServer(port);

--- a/src/utils/middleware-injector.ts
+++ b/src/utils/middleware-injector.ts
@@ -1,11 +1,15 @@
 import {ConcatSource} from "webpack-sources";
 
-export default function middlewareInjector(compilation, source: string) {
-    compilation.plugin('after-optimize-chunk-assets', chunks => chunks.forEach(chunk => {
-        chunk.files.forEach(fileName => {
-            if (/\.js$/.test(fileName)) {
-                compilation.assets[fileName] = new ConcatSource(source, compilation.assets[fileName]);
-            }
-        });
-    }));
+export default function middlewareInjector(compilation, source: string, excludedChunks: Array<string>) {
+    compilation.plugin('after-optimize-chunk-assets', chunks =>
+        chunks
+            // skip excluded chunks.
+            .filter(chunk => !excludedChunks.includes(chunk.name))
+            .forEach(chunk => {
+                chunk.files.forEach(fileName => {
+                    if (/\.js$/.test(fileName)) {
+                        compilation.assets[fileName] = new ConcatSource(source, compilation.assets[fileName]);
+                    }
+                });
+            }));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,13 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "lib": [
+      "DOM",
+      "ES6",
+      "ScriptHost",
+      "DOM.Iterable",
+      "ES2016.Array.Include"
+    ],
     "target": "es6",
     "sourceMap": true,
     "module": "commonjs",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,7 @@ declare type ActionType = string;
 declare type Action = { type: ActionType, payload?: any };
 declare type ActionFactory = (payload?: any) => Action;
 
-declare type PluginOptions = { port: number, reloadPage: boolean, entries: EntriesOption };
+declare type PluginOptions = { port: number, reloadPage: boolean, entries: EntriesOption, excludedChunks: Array<string> };
 declare type EntriesOption = { background: string, contentScript: string };
 
 declare type MiddlewareTemplateParams = { port: number, reloadPage: boolean };


### PR DESCRIPTION
in my use case some of webpack chunks does not run in a context where "chrome" global is available to them.
The code injected by the plugin fails and the extension fails to run.
The change enables declaring which entries/chunks shouldn't be altered by the injection middleware.