### PR TITLE
reload extension after assets have been emitted

### DIFF
--- a/src/ChromeExtensionReloader.ts
+++ b/src/ChromeExtensionReloader.ts
@@ -29,7 +29,7 @@ export default class ChromeExtensionReloader extends AbstractChromePluginReloade
         const server = new HotReloaderServer(port);
         server.listen();
 
-        compiler.plugin("emit", (comp, call) => {
+        compiler.plugin("after-emit", (comp, call) => {
             if (this._hash !== comp.hash) {
                 this._hash = comp.hash;
                 server.signChange(reloadPage, call);


### PR DESCRIPTION
Currently the extension reload is called on "emit" this is [when "The compilation is going to emit files..."](https://webpack.github.io/docs/plugins.html) not when the files have actually been emitted. 

This results in a race condition were we are relying on reload taking longer than the emit action.

By triggering on "after-emit" we no longer have this problem.

To test this please create a very large extension ( over 1.5mb ) that will take a few second for webpack to compile. On my machine it results in a full extension and page reload happening before new build files are written to disk.

