### PR TITLE
Fixes issue with errors from websockets package. Closes #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "colors": "^1.1.2",
     "lodash": "^4.17.4",
     "webpack-sources": "^1.0.1",
-    "ws": "^3.0.0"
+    "ws": "3.3.3"
   },
   "peerDependencies": {
     "webpack": "^2.2.1 | ^3.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "colors": "^1.1.2",
     "lodash": "^4.17.4",
     "webpack-sources": "^1.0.1",
-    "ws": "3.3.3"
+    "ws": "^3.3.3"
   },
   "peerDependencies": {
     "webpack": "^2.2.1 | ^3.0.0"

--- a/sample/plugin/manifest.json
+++ b/sample/plugin/manifest.json
@@ -16,7 +16,7 @@
         "content-script.js"
       ],
       "css": [
-        "sample.css"
+        "style.css"
       ]
     }
   ]

--- a/src/utils/HotReloaderServer.ts
+++ b/src/utils/HotReloaderServer.ts
@@ -21,6 +21,9 @@ export default class HotReloaderServer {
       ws.on("message", (data: string) =>
         info(`Message from the client: ${JSON.parse(data).payload}`)
       );
+      ws.on("error", () => {
+        // NOOP - swallow socket errors due to http://git.io/vbhSN
+      });
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5324,19 +5324,19 @@ ws@1.1.4:
     options ">=0.0.5"
     ultron "1.0.x"
 
-ws@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
-  dependencies:
-    async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
-
 ws@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
   dependencies:
     safe-buffer "~5.0.1"
+    ultron "~1.1.0"
+
+ws@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
 wtf-8@1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -4504,7 +4508,7 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1:
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -5320,16 +5324,17 @@ ws@1.1.4:
     options ">=0.0.5"
     ultron "1.0.x"
 
+ws@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
 ws@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
-  dependencies:
-    safe-buffer "~5.0.1"
-    ultron "~1.1.0"
-
-ws@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
   dependencies:
     safe-buffer "~5.0.1"
     ultron "~1.1.0"


### PR DESCRIPTION
By adding an on error handler we ensure errors emanating from **ws** do not bring the server down.

The handler is a NO OP but prevents an actual js error being thrown.

Also fixed reference to renamed stylesheet in sample extension 