### PR TITLE
chore(dependencies): update webpack peer dependency v2 - v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ws": "^3.3.3"
   },
   "peerDependencies": {
-    "webpack": "2 | 3"
+    "webpack": "2 | 3 | 4"
   },
   "devDependencies": {
     "@types/chai": "^4.0.0",


### PR DESCRIPTION
Webpack 4 is stable and your great extension works like a charm with current version 4.1.0.
Closes #34 