### PR TITLE
Implemented option entries.extra and CLI argument --extra-entries #36

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -60,7 +60,7 @@ wcer
 If you run directly, it will use the  default configurations, but if you want to customize
 you can call it with the following options:
 ```bash
-wcer --config wb.config.js --port 9080 --no-page-reload content-script my-content.js --background bg.js --extra-entries extra-a;extra-b
+wcer --config wb.config.js --port 9080 --no-page-reload --content-script my-content --background bg --extra-entries extra-a;extra-b
 ```
 ### Client options
 

--- a/README.MD
+++ b/README.MD
@@ -38,9 +38,10 @@ plugins: [
     new ChromeExtensionReloader({
       port: 9090, // Which port use to create the server
       reloadPage: true, // Force the reload of the page also
-      entries: { //The entries used for the content/background scripts
-        contentScript: 'content-script', //Use the entry names, not the file name or the path
-        background: 'background'
+      entries: { // The entries used for the content/background scripts
+        contentScript: 'content-script', // Use the entry names, not the file name or the path
+        background: 'background',
+        extra: [] // Additional entry names
       }
     })
 ]
@@ -59,7 +60,7 @@ wcer
 If you run directly, it will use the  default configurations, but if you want to customize
 you can call it with the following options:
 ```bash
-wcer --config wb.config.js --port 9080 --no-page-reload content-script my-content.js --background bg.js 
+wcer --config wb.config.js --port 9080 --no-page-reload content-script my-content.js --background bg.js --extra-entries extra-a;extra-b
 ```
 ### Client options
 
@@ -69,6 +70,7 @@ wcer --config wb.config.js --port 9080 --no-page-reload content-script my-conten
 | --port             | 9090              | The port to run the server                                        |
 | --content-script   | content-script    | The **entry** name for the content script                         |
 | --background       | background        | The **entry** name for the background script                      |
+| --extra-entries    |                   | Additional **entry** names split by ;                             |
 | --no-page-reload   |                   | Disable the auto reloading of all **pages** which runs the plugin |
 
 Every time webpack triggers a compilation, the extension reloader are going to do the hot reload :)  

--- a/client/args.constant.ts
+++ b/client/args.constant.ts
@@ -3,3 +3,4 @@ export const PORT = "port";
 export const NO_PAGE_RELOAD = "no-page-reload";
 export const BACKGROUND_ENTRY = "background";
 export const CONTENT_SCRIPT_ENTRY = "content-script";
+export const EXTRA_ENTRIES = "extra-entries";

--- a/client/index.ts
+++ b/client/index.ts
@@ -8,6 +8,7 @@ import {
   BACKGROUND_ENTRY,
   CONFIG,
   CONTENT_SCRIPT_ENTRY,
+  EXTRA_ENTRIES,
   NO_PAGE_RELOAD,
   PORT
 } from "./args.constant";
@@ -15,6 +16,7 @@ import {
   DEFAULT_BACKGROUND_ENTRY,
   DEFAULT_CONFIG,
   DEFAULT_CONTENT_SCRIPT_ENTRY,
+  DEFAULT_EXTRA_ENTRIES,
   DEFAULT_PORT
 } from "../src/constants/options.constants";
 
@@ -27,11 +29,14 @@ const port = params[PORT] || DEFAULT_PORT;
 const contentScript =
   params[CONTENT_SCRIPT_ENTRY] || DEFAULT_CONTENT_SCRIPT_ENTRY;
 const background = params[BACKGROUND_ENTRY] || DEFAULT_BACKGROUND_ENTRY;
+const extraEntries =
+  (params[EXTRA_ENTRIES] && params[EXTRA_ENTRIES].split(";")) ||
+  DEFAULT_EXTRA_ENTRIES;
 
 const pluginOptions: PluginOptions = {
   port,
   reloadPage: !params[NO_PAGE_RELOAD],
-  entries: { contentScript, background }
+  entries: { contentScript, background, extra: extraEntries }
 };
 
 const optPath = resolve(cwd(), config);

--- a/sample/plugin/style.css
+++ b/sample/plugin/style.css
@@ -1,1 +1,1 @@
-body { backgroud: black; }
+body { background: black; }

--- a/src/constants/options.constants.ts
+++ b/src/constants/options.constants.ts
@@ -3,3 +3,4 @@ export const DEFAULT_CONFIG = "webpack.config.js";
 export const DEFAULT_RELOAD_PAGE = true;
 export const DEFAULT_CONTENT_SCRIPT_ENTRY = "content-script";
 export const DEFAULT_BACKGROUND_ENTRY = "background";
+export const DEFAULT_EXTRA_ENTRIES = [];

--- a/src/utils/default-options.ts
+++ b/src/utils/default-options.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_BACKGROUND_ENTRY,
   DEFAULT_CONTENT_SCRIPT_ENTRY,
+  DEFAULT_EXTRA_ENTRIES,
   DEFAULT_PORT,
   DEFAULT_RELOAD_PAGE
 } from "../constants/options.constants";
@@ -10,6 +11,7 @@ export default {
   port: DEFAULT_PORT,
   entries: {
     contentScript: DEFAULT_CONTENT_SCRIPT_ENTRY,
-    background: DEFAULT_BACKGROUND_ENTRY
+    background: DEFAULT_BACKGROUND_ENTRY,
+    extra: DEFAULT_EXTRA_ENTRIES
   }
 };

--- a/src/utils/middleware-injector.ts
+++ b/src/utils/middleware-injector.ts
@@ -1,11 +1,17 @@
+import { includes } from "lodash";
+
 export default function middlewareInjector(
-  { background, contentScript }: EntriesOption,
+  { background, contentScript, extra }: EntriesOption,
   source: string,
   sourceFactory: SourceFactory
 ) {
   return (assets: object, chunks: WebpackChunk[]) =>
     chunks.reduce((prev, { name, files }) => {
-      if (name === background || name === contentScript) {
+      if (
+        name === background ||
+        name === contentScript ||
+        includes(extra || [], name)
+      ) {
         const [entryPoint] = files;
         if (/\.js$/.test(entryPoint)) {
           prev[entryPoint] = sourceFactory(source, assets[entryPoint]);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@ declare type Action = { type: ActionType, payload?: any };
 declare type ActionFactory = (payload?: any) => Action;
 
 declare type PluginOptions = { port: number, reloadPage: boolean, entries: EntriesOption };
-declare type EntriesOption = { background: string, contentScript: string };
+declare type EntriesOption = { background: string, contentScript: string, extra?: string[] };
 
 declare type MiddlewareTemplateParams = { port: number, reloadPage: boolean };
 


### PR DESCRIPTION
**Fix for [issue #36](https://github.com/rubenspgcavalcante/webpack-chrome-extension-reloader/issues/36)**

These changes introduce a new String[] option `entries.extra` and a new CLI argument `--extra-entries` (split by `;`) for listening to changes of custom Webpack entries that are neither `background.js` nor `content-script.js`.

This pull request also includes fixes for the command line example in `README.MD` and a minor fix for `sample/plugin/style.css`.

I am not quite familiar with TypeScript and I may have missed something. Feel free to point out any mistakes! :)