### PR TITLE
Fixed exposed definitions

### DIFF
--- a/src/ChromeExtensionReloader.ts
+++ b/src/ChromeExtensionReloader.ts
@@ -9,12 +9,13 @@ import { bgScriptRequiredMsg } from "./messages/errors";
 import { warn } from "./utils/logger";
 
 import { Compiler } from "webpack";
-import ChromeExtensionReloader, {
+import {
+  ChromeExtensionReloaderInstance,
   PluginOptions
 } from "webpack-chrome-extension-reloader";
 
 export default class ChromeExtensionReloaderImpl extends AbstractChromePluginReloader
-  implements ChromeExtensionReloader {
+  implements ChromeExtensionReloaderInstance {
   private _opts?: PluginOptions;
   constructor(options?: PluginOptions) {
     super();

--- a/typings/webpack-chrome-extension-reloader.d.ts
+++ b/typings/webpack-chrome-extension-reloader.d.ts
@@ -11,11 +11,11 @@ declare module "webpack-chrome-extension-reloader" {
 
   type ContentScriptOption = string | Array<string>;
 
-  interface ChromeExtensionReloaderConstructor {
-    new (options?: PluginOptions): ChromeExtensionReloader;
+  export default interface ChromeExtensionReloader {
+    new (options?: PluginOptions): ChromeExtensionReloaderInstance;
   }
 
-  export default interface ChromeExtensionReloader {
+  export interface ChromeExtensionReloaderInstance {
     apply(compiler: Object): void;
   }
 }


### PR DESCRIPTION
Exposing plugin constructor interface as default instead of instance interface. Closes #78 